### PR TITLE
Dockerfile: permit to use as baseimage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,6 @@ RUN set -x \
     && apt-get install --quiet --yes --no-install-recommends git-lfs \
     && git lfs install \
     && apt-get install --quiet --yes --no-install-recommends -t jessie-backports libtcnative-1 \
-    && dpkg --purge apt-transport-https \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
     && mkdir -p               "${BAMBOO_HOME}/lib" \


### PR DESCRIPTION
Since commit c9c931f096fa73f8062d4513e9dc44a1c50f4837 it is not possible to use `cptactionhank/bamboo` as a baseimage: to fix the issue we reinclude `apt-transport-https`.