### PR TITLE
Add jessie backports to apt source list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ build/
 
 # unless supporting rvm < 1.11.0 or doing something fancy, ignore this:
 .rvmrc
+
+# Agregados Cybersyn
+data

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,7 @@ EXPOSE 8085 54663
 # Set volume mount points for installation and home directory. Changes to the
 # home directory needs to be persisted as well as parts of the installation
 # directory due to eg. logs.
-VOLUME ["/var/atlassian/bamboo","/opt/atlassian/bamboo/logs"]
+VOLUME ["/var/atlassian/bamboo","/opt/atlassian/bamboo"]
 
 # Set the default working directory as the Bamboo home directory.
 WORKDIR /var/atlassian/bamboo

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,8 @@ RUN set -x \
     && curl --silent https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash \
     && apt-get install --quiet --yes --no-install-recommends git-lfs \
     && git lfs install \
+    && echo "deb http://ftp.debian.org/debian jessie-backports main" | tee -a /etc/apt/sources.list \
+    && apt-get update \
     && apt-get install --quiet --yes --no-install-recommends -t jessie-backports libtcnative-1 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ ENV BAMBOO_VERSION  6.0.3
 RUN set -x \
     && apt-get update --quiet \
     && apt-get install --quiet --yes --no-install-recommends xmlstarlet \
+    && apt-get install --quiet --yes --no-install-recommends maven \
     && curl --silent https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash \
     && apt-get install --quiet --yes --no-install-recommends git-lfs \
     && git lfs install \
@@ -22,6 +23,9 @@ RUN set -x \
     && chmod -R 700           "${BAMBOO_HOME}" \
     && chown -R daemon:daemon "${BAMBOO_HOME}" \
     && mkdir -p               "${BAMBOO_INSTALL}" \
+    && mkdir                   /usr/bin/.m2 \
+    && chmod -R 700            /usr/bin/.m2 \
+    && chown -R daemon:daemon  /usr/bin/.m2 \
     && curl -Ls               "https://www.atlassian.com/software/bamboo/downloads/binary/atlassian-bamboo-${BAMBOO_VERSION}.tar.gz" | tar -zx --directory  "${BAMBOO_INSTALL}" --strip-components=1 --no-same-owner \
     && curl -Ls                "https://dev.mysql.com/get/Downloads/Connector-J/mysql-connector-java-5.1.40.tar.gz" | tar -xz --directory "${BAMBOO_INSTALL}/lib" --strip-components=1 --no-same-owner "mysql-connector-java-5.1.40/mysql-connector-java-5.1.40-bin.jar" \
     && chmod -R 700           "${BAMBOO_INSTALL}" \
@@ -45,7 +49,7 @@ EXPOSE 8085 54663
 # Set volume mount points for installation and home directory. Changes to the
 # home directory needs to be persisted as well as parts of the installation
 # directory due to eg. logs.
-VOLUME ["/var/atlassian/bamboo","/opt/atlassian/bamboo"]
+VOLUME ["/var/atlassian/bamboo","/opt/atlassian/bamboo","/usr/sbin/.m2/repository"]
 
 # Set the default working directory as the Bamboo home directory.
 WORKDIR /var/atlassian/bamboo

--- a/README.md
+++ b/README.md
@@ -35,3 +35,19 @@ If you see out of date documentation, lack of tests, etc., you can help out by e
 - sending a pull request with modifications (remember to read [contributing guide](https://github.com/cptactionhank/docker-atlassian-bamboo/blob/master/CONTRIBUTING.md) before.)
 
 Continuous Integration and Continuous Delivery is made possible with the great services from [GitHub](https://github.com), [Travis CI](https://travis-ci.org/), and [CircleCI](https://circleci.com/) written in [Ruby](https://www.ruby-lang.org/), using [RSpec](http://rspec.info/), [Capybara](https://jnicklas.github.io/capybara/), and [PhantomJS](http://phantomjs.org/) frameworks.
+----
+
+/home/rvaldes/Contenedores/docker-atlassian-bamboo
+
+
+docker run --detach --publish 8085:8085 --name cybersyn-ci -v /home/rvaldes/Contenedores/docker-atlassian-bamboo/data/bamboo/atlassian/bamboo:/var/atlassian/bamboo -v /home/rvaldes/Contenedores/docker-atlassian-bamboo/data/bamboo-install/bamboo:/opt/atlassian/bamboo cybersyn/bamboo
+
+/home/rvaldes/Contenedores/docker-atlassian-bamboo/data/bamboo-install/bamboo
+
+docker run --detach --publish 8085:8085 --name cybersyn-ci 
+
+
+ENV BAMBOO_HOME     /var/atlassian/bamboo
+ENV BAMBOO_INSTALL  /opt/atlassian/bamboo
+
+

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -10,7 +10,7 @@ BAMBOO_DATA=$1
 #/home/rvaldes/Contenedores/docker-atlassian-bamboo
 
 
-docker run --detach --publish 8085:8085 --name cybersyn-ci -v $BAMBOO_DATA/data/bamboo-home:/var/atlassian/bamboo -v $BAMBOO_DATA/data/bamboo-install:/opt/atlassian/bamboo cybersyn/bamboo
+docker run --detach --publish 8085:8085 --name cybersyn-ci -v $BAMBOO_DATA/data/bamboo-home:/var/atlassian/bamboo -v $BAMBOO_DATA/data/bamboo-install:/opt/atlassian/bamboo -v $BAMBOO_DATA/data/maven-repo:/usr/sbin/.m2/repository cybersyn/bamboo
 
 #/home/rvaldes/Contenedores/docker-atlassian-bamboo/data/bamboo-install/bamboo
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+#set -x
+
+BAMBOO_DATA=$1
+
+#echo $BAMBOO_HOME
+#echo $BAMBOO_INSTALL
+
+#/home/rvaldes/Contenedores/docker-atlassian-bamboo
+
+
+docker run --detach --publish 8085:8085 --name cybersyn-ci -v $BAMBOO_DATA/data/bamboo-home:/var/atlassian/bamboo -v $BAMBOO_DATA/data/bamboo-install:/opt/atlassian/bamboo cybersyn/bamboo
+
+#/home/rvaldes/Contenedores/docker-atlassian-bamboo/data/bamboo-install/bamboo
+
+#docker run --detach --publish 8085:8085 --name cybersyn-ci 
+
+
+#ENV BAMBOO_HOME     /var/atlassian/bamboo
+#ENV BAMBOO_INSTALL  /opt/atlassian/bamboo
+


### PR DESCRIPTION
Was getting the following error building container:

`Reading package lists...
Reading package lists...
E: The value 'jessie-backports' is invalid for APT::Default-Release as such a release is not available in the sources`

I fixed it adding jessie-backports to apt source list and updating.