### PR TITLE
Updated Version to 6.2.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM openjdk:8-alpine
 # Setup useful environment variables
 ENV BAMBOO_HOME     /var/atlassian/bamboo
 ENV BAMBOO_INSTALL  /opt/atlassian/bamboo
-ENV BAMBOO_VERSION  6.2.3
+ENV BAMBOO_VERSION  6.2.5
 
 # Install Atlassian Bamboo and helper tools and setup initial home
 # directory structure.


### PR DESCRIPTION
6.2.5 has an important security patch.

>Atlassian
Security advisory for Bamboo
Hello Kai,
We are writing to inform you of a critical security vulnerability that exists in Bamboo before version 6.1.6 (the fixed version for 6.1.x) and from version 6.2.0 before 6.2.5 (the fixed version for 6.2.x).
Customers who have upgraded Bamboo to version 6.1.6 or version 6.2.5 are not affected.
How do you fix it?
Customers who have downloaded and installed Bamboo, follow the instructions provided in the detailed security advisory:
•Bamboo Security Advisory
If you have questions or concerns, please raise a support request. One of our support engineers will be happy to help you.
Kind regards,
Atlassian