### PR TITLE
Install tzdata package to support timezones other than UTC+00 on the …

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ ENV BAMBOO_VERSION  6.7.1
 RUN set -x \
     && addgroup -S bamboo \
     && adduser -S -h "${BAMBOO_HOME}" bamboo bamboo \
-    && apk add --no-cache curl xmlstarlet git openssh bash ttf-dejavu libc6-compat \
+    && apk add --no-cache curl xmlstarlet git openssh bash ttf-dejavu libc6-compat tzdata \
     && mkdir -p               "${BAMBOO_HOME}/lib" \
     && chmod -R 700           "${BAMBOO_HOME}" \
     && chown -R bamboo:bamboo "${BAMBOO_HOME}" \

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ You can configure a small set of things by supplying the following environment v
 | X_PROXY_PORT           | Sets the Tomcat Connectors `ProxyPort` attribute |
 | X_PROXY_SCHEME         | If set to `https` the Tomcat Connectors `secure=true` and `redirectPort` equal to `X_PROXY_PORT`   |
 | X_PATH                 | Sets the Tomcat connectors `path` attribute |
+| TZ                     | Sets the timezone used by the Bamboo server. E.g. `Europe/Berlin` |
 
 ## Contributions
 


### PR DESCRIPTION
## Summary

This PR makes sure the tzdata package is installed so custom timezones can be set instead of always running the server on UTC+00.

## Context:

I'm running several remote agents with the timezone set according to my office location. Whenever the Bamboo server generates a timestamp (such as build start timestamps etc.) this timestamp would be an UTC+00 timestamp whereas the timestamps generated by agents or builds would use the timezone set on the agent machines.

## Howto

Now the timezone on the Bamboo server can be changed by simply supplying the `TZ` environment variable to the container:

```
docker run --detach --publish 8085:8085 --env=TZ=Europe/Berlin cptactionhank/atlassian-bamboo:latest
```