### PR TITLE
Defined a specific system with HOME directory to ${BAMBOO_HOME}

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,15 +8,17 @@ ENV BAMBOO_VERSION  6.5.0
 # Install Atlassian Bamboo and helper tools and setup initial home
 # directory structure.
 RUN set -x \
+    && addgroup -S bamboo \
+    && adduser -S -h "${BAMBOO_HOME}" bamboo bamboo \
     && apk add --no-cache curl xmlstarlet git openssh bash ttf-dejavu libc6-compat \
     && mkdir -p               "${BAMBOO_HOME}/lib" \
     && chmod -R 700           "${BAMBOO_HOME}" \
-    && chown -R daemon:daemon "${BAMBOO_HOME}" \
+    && chown -R bamboo:bamboo "${BAMBOO_HOME}" \
     && mkdir -p               "${BAMBOO_INSTALL}" \
     && curl -Ls               "https://www.atlassian.com/software/bamboo/downloads/binary/atlassian-bamboo-${BAMBOO_VERSION}.tar.gz" | tar -zx --directory  "${BAMBOO_INSTALL}" --strip-components=1 --no-same-owner \
     && curl -Ls                "https://dev.mysql.com/get/Downloads/Connector-J/mysql-connector-java-5.1.40.tar.gz" | tar -xz --directory "${BAMBOO_INSTALL}/lib" --strip-components=1 --no-same-owner "mysql-connector-java-5.1.40/mysql-connector-java-5.1.40-bin.jar" \
     && chmod -R 700           "${BAMBOO_INSTALL}" \
-    && chown -R daemon:daemon "${BAMBOO_INSTALL}" \
+    && chown -R bamboo:bamboo "${BAMBOO_INSTALL}" \
     && sed --in-place         's/^# umask 0027$/umask 0027/g' "${BAMBOO_INSTALL}/bin/setenv.sh" \
     && xmlstarlet             ed --inplace \
         --delete              "Server/Service/Engine/Host/@xmlValidation" \
@@ -28,7 +30,7 @@ RUN set -x \
 # Use the default unprivileged account. This could be considered bad practice
 # on systems where multiple processes end up being executed by 'daemon' but
 # here we only ever run one process anyway.
-USER daemon:daemon
+USER bamboo:bamboo
 
 # Expose default HTTP and SSH ports.
 EXPOSE 8085 54663


### PR DESCRIPTION
## Summary
This PR makes the HOME directory of bamboo writeable, enabling bamboo to store some build resources, such as SSH Credentials, or gradle cache.
fixes #13

## Context:
As explained in the issue #13, with the daemon user bamboo wasn't able to store data to its home directory, in my case it was my shared ssh credentials.
To fix the issue I've added a Group and a User, with system characteristics (no login), but with the HOME directory set to ${BAMBOO_HOME} (/var/atlassian/bamboo), also changed all references from the daemon user to bamboo