### PR TITLE
Feature/add docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,13 +22,10 @@ RUN set -x \
         --delete              "Server/Service/Engine/Host/@xmlValidation" \
         --delete              "Server/Service/Engine/Host/@xmlNamespaceAware" \
                               "${BAMBOO_INSTALL}/conf/server.xml" \
-    && touch -d "@0"          "${BAMBOO_INSTALL}/conf/server.xml"
-
-
-# Use the default unprivileged account. This could be considered bad practice
-# on systems where multiple processes end up being executed by 'daemon' but
-# here we only ever run one process anyway.
-USER daemon:daemon
+    && touch -d "@0"          "${BAMBOO_INSTALL}/conf/server.xml" \
+    && apk add docker \
+    && apk add py-pip \
+    && pip install docker-compose
 
 # Expose default HTTP and SSH ports.
 EXPOSE 8085 54663

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,8 +25,7 @@ RUN set -x \
     && touch -d "@0"          "${BAMBOO_INSTALL}/conf/server.xml" \
     && apk add docker \
     && apk add py-pip \
-    && pip install docker-compose \
-    && apk add grep
+    && pip install docker-compose
 
 # Expose default HTTP and SSH ports.
 EXPOSE 8085 54663

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,8 @@ RUN set -x \
     && touch -d "@0"          "${BAMBOO_INSTALL}/conf/server.xml" \
     && apk add docker \
     && apk add py-pip \
-    && pip install docker-compose
+    && pip install docker-compose \
+    && apk add grep
 
 # Expose default HTTP and SSH ports.
 EXPOSE 8085 54663

--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ To quickly get started running a Bamboo instance, use the following command:
 ```bash
 docker run --detach --publish 8085:8085 cptactionhank/atlassian-bamboo:latest
 ```
+or, if you want to use Docker inside image:
+```bash
+docker run --detach --publish 8085:8085 -v /var/run/docker.sock:/var/run/docker.sock cptactionhank/atlassian-bamboo:latest
+```
 
 Then simply navigate to [`http://localhost:8085`](http://localhost:8085) and finish the installation.
 


### PR DESCRIPTION
# Summary
This PR allows using Docker from Bamboo container. Both, _docker_ and _docker-compose_ commands are available in Bamboo.
# Context
Docker daemon is provided by a volume, because of the risk of the data corruption, explained here:
http://jpetazzo.github.io/2015/09/03/do-not-use-docker-in-docker-for-ci/
Because Docker needs a root user, the unprivileged account will not work with it.
# Howto
To run a Docker daemon inside Bamboo container, volume with a default docker.sock need to be provided:
```bash
docker run --detach --publish 8085:8085 -v /var/run/docker.sock:/var/run/docker.sock mattkoboski/bamboo-server:latest
```